### PR TITLE
Update Graphs description

### DIFF
--- a/src/apps.ts
+++ b/src/apps.ts
@@ -627,7 +627,7 @@ const apps: App[] = [
   {
     id: "se.sjoerd.Graphs",
     name: "Graphs",
-    desc: "Plot and manipulate data in a breeze",
+    desc: "Plot and manipulate data",
     lang: Lang.Python,
   },
   {


### PR DESCRIPTION
We updated the Graphs short description to match the new appdata guidelines, where more than 30 characters are discouraged. This PR just updates the description to match that.