### PR TITLE
Add API route for app list

### DIFF
--- a/src/routes/api/apps/+server.ts
+++ b/src/routes/api/apps/+server.ts
@@ -1,0 +1,6 @@
+import { json } from '@sveltejs/kit';
+import { APP_LANGUAGES } from '$lib/apps';
+
+export function GET() {
+    return json(APP_LANGUAGES);
+}


### PR DESCRIPTION
This PR adds a route under `/api/apps` that returns the app list in JSON format.

We would like to use this data in [Bazaar](https://github.com/kolunmi/bazaar) to list and promote Adwaita apps to our users using GNOME.